### PR TITLE
Add runnable CapCut-style editor demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository now includes a runnable CapCut-style web demo alongside the design blueprint.
 
+This branch (`work`) contains the up-to-date demo files that were used in the preview, so pulling
+or cloning it will provide the same runnable experience described below.
+
 ## What's here
 - `capcut_design.md`: Product and UX blueprint for a CapCut-style editor.
 - `index.html`, `style.css`, `script.js`: A static front-end prototype with timeline, preview, text overlays, and markers.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This repository now includes a runnable CapCut-style web demo alongside the desi
 This branch (`work`) contains the up-to-date demo files that were used in the preview, so pulling
 or cloning it will provide the same runnable experience described below.
 
+If you need to mirror these assets to another branch (e.g., `codex/design-a-capcut-feature`),
+copy the current `index.html`, `style.css`, `script.js`, `capcut_design.md`, and `README.md`
+from this branch to keep the demo aligned with the latest preview state.
+
 ## What's here
 - `capcut_design.md`: Product and UX blueprint for a CapCut-style editor.
 - `index.html`, `style.css`, `script.js`: A static front-end prototype with timeline, preview, text overlays, and markers.

--- a/README.md
+++ b/README.md
@@ -13,4 +13,18 @@ The demo is a static page. From the repo root, start a simple server and open th
 python -m http.server 8000
 ```
 
-Then navigate to [http://localhost:8000](http://localhost:8000) to interact with the editor UI. Use the **Add B-Roll Clip** and **Add Text Overlay** buttons to populate the timeline and adjust properties in the Inspector.
+Then navigate to [http://localhost:8000](http://localhost:8000) to interact with the editor UI. Use the **Add B-Roll Clip** and
+**Add Text Overlay** buttons to populate the timeline and adjust properties in the Inspector.
+
+## 目前 Demo 已实现的功能
+
+- 可用功能：
+  - Library/Quick adds 会追加带 start/duration 的 clip，并在时间线中渲染。
+  - 点击时间线 clip 会跳到对应播放时间、自动填充 Inspector，并高亮当前播放位置所属的 clip。
+  - Inspector 中的 label/start/duration/text 可编辑（对文本覆盖启用），Update 后立即更新 UI。
+  - Text Overlay clip 在播放时会显示到预览上方，并与时间线同步高亮。
+  - Add Marker 会在当前时间创建标记，列表中可编辑 label，点击可跳转到对应时间。
+
+- 暂未实现/占位：
+  - Import/Export 按钮仅为示意，未接入真实文件管线。
+  - 仅支持单轨简单时间线；高级特效、转场、波形等仍为后续扩展空间。

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Codex-
+
+This repository now includes a runnable CapCut-style web demo alongside the design blueprint.
+
+## What's here
+- `capcut_design.md`: Product and UX blueprint for a CapCut-style editor.
+- `index.html`, `style.css`, `script.js`: A static front-end prototype with timeline, preview, text overlays, and markers.
+
+## How to run
+The demo is a static page. From the repo root, start a simple server and open the URL in your browser:
+
+```bash
+python -m http.server 8000
+```
+
+Then navigate to [http://localhost:8000](http://localhost:8000) to interact with the editor UI. Use the **Add B-Roll Clip** and **Add Text Overlay** buttons to populate the timeline and adjust properties in the Inspector.

--- a/capcut_design.md
+++ b/capcut_design.md
@@ -1,0 +1,115 @@
+# CapCut-Style Video Editor Design
+
+## Product Goal
+Deliver a fast, friendly, cross-platform video editor that lowers the barrier to polished short-form content while still supporting pro-grade workflows.
+
+## Target Users
+- **Creators & social teams:** quick edits, templates, trending effects.
+- **Vloggers & educators:** narration, subtitles, multi-track assembly.
+- **Prosumers:** color, audio mixing, keyframes, precise trimming.
+
+## Core Principles
+1. **Speed to publish:** frictionless import, presets for export, background rendering.
+2. **Clarity:** clean hierarchy, consistent iconography, contextual helpers.
+3. **Confidence:** granular undo/redo, autosave, version history.
+4. **Delight:** smooth animations, responsive scrubbing, live previews.
+
+## Information Architecture
+- **Top bar:** project name, cloud sync status, undo/redo, export, account.
+- **Left rail:** media bin, stock assets, text, stickers, transitions, effects.
+- **Center canvas:** viewer with overlays (safe guides, snapping hints) and mode toggles (fit/fill, background blur).
+- **Bottom timeline:** stacked tracks (video, overlay, audio, captions, FX) with collapsible height and ripple trim.
+- **Right inspector:** contextual properties for selected clip (transform, speed, audio, color, effects, captions).
+
+## Key Flows
+### Project creation
+- New project wizard (canvas size, fps, background), template gallery, or recent projects.
+- Cloud projects auto-sync; offline edits queued.
+
+### Import & organization
+- Drag-and-drop from desktop, device camera roll, cloud drives.
+- Smart folders (Favorites, Used, Unused), search by label/people/object (ML tags), bulk relink.
+
+### Editing & timeline
+- Ripple/roll/slip/slide trims with visual diff for in/out frames.
+- Snapping to markers, beats, captions, and clip edges.
+- Magnetic timeline option; gap removal; selective ripple per track.
+- Multi-select with lasso/shift-click; grouping; nested sequences.
+- Speed ramp editor with bezier handles; reverse; time remapping presets.
+- Keyframes for transform/opacity/effects; on-canvas controls for scale/position/rotation.
+- Track locks, mutes, solos; role colors (dialogue, SFX, music, B-roll).
+- Markers with comments/mentions; review mode to approve changes.
+
+### Audio
+- Waveform scrubbing; beat detection; auto-ducking against dialogue.
+- Voice isolation, noise reduction, loudness normalization.
+- Parametric EQ presets; reverb/echo library; pitch shift with formant control.
+- Transcript-based editing: delete text to cut media; search & replace words.
+
+### Text & captions
+- Auto-captions with multilingual support; style presets; animated text behaviors.
+- Subtitle editor with spellcheck, timing nudge, and translation track.
+- Kinetic typography templates; 3D text; stroke/shadow/gradient controls.
+
+### Effects & compositing
+- Blend modes, LUTs, curves, HSL; selective color mask; vignette; glow.
+- Green/blue screen keying; rotoscope/matting with feather; background blur.
+- Motion tracking for stickers/text/effects; planar tracker for screen replacements.
+- Transition library with favorites; adjustable easing; preview-on-hover.
+
+### Assets & templates
+- Stock media hub (music, stickers, overlays, Lottie animations, SFX) with licensing filter.
+- Template browser with category filters (social/ads/education), A/B performance notes, replaceable drop zones.
+- Presets for export (TikTok, Reels, Shorts, 16:9 YouTube) and custom profile save.
+
+### Collaboration & review
+- Shared projects with roles (editor, reviewer, viewer); per-timeline-clip comments.
+- Live cursors when co-editing; edit locks on active clips; change history with diff.
+- Review links with timecoded comments; approval status per revision.
+
+### Delivery
+- Export queue with background rendering; cloud export; upload to social accounts.
+- Deliverables: video, audio-only, GIF, image sequence, EDL/AAF/AAF XML.
+- Quality controls: bitrate modes (target/constant), VBR/CBR, hardware acceleration, color management (Rec.709/2020, HDR10/HLG), audio stem exports.
+
+## Interactions & Microcopy
+- Hover states show shortcuts; tooltips with GIF demos for advanced tools.
+- Scrub jog via scroll/shift-scroll; JKL playback; K = pause, double-tap = play head to marker.
+- Smooth zoom/pan on timeline with two-finger/scroll + modifier; snap zoom to clip.
+- Status toasts for background tasks (rendering, uploads, sync).
+
+## Visual System
+- **Palette:** dark UI (#0f1115) with accent highlights (#00e0b8) and neutrals for hierarchy.
+- **Typography:** clean sans (Inter/Roboto); small caps for rail labels; monospace for timecode.
+- **Iconography:** thin-stroke, filled on active; consistent grid.
+- **Depth:** layer blur/shadows for floating panels; subtle glass for inspector.
+- **Feedback:** elastic easing on drag; micro haptics (mobile); glow on active playhead.
+
+## Accessibility
+- WCAG AA contrast; scalable UI density; caption + transcript for all audio.
+- Keyboard coverage for all actions; shortcut remapper; screen-reader labels and focus order.
+- Color-blind-safe indicators (shape + color); vibration alternatives.
+
+## Performance & Reliability
+- Incremental rendering; proxy/resolution switching; smart cache invalidation.
+- GPU-accelerated effects; background prefetch of next clips; low-latency audio playback.
+- Crash recovery with snapshots; autosave interval; conflict resolution on sync.
+
+## Settings & Customization
+- Layout presets (Beginner, Creator, Pro); detachable panels; dual-monitor mode.
+- Custom workspaces per task (Captions, Color, Audio Mix, Effects).
+- Preference sync across devices; project templates with default tracks/effects.
+
+## Growth & Monetization
+- Free core with watermark-free exports up to a threshold; premium for advanced FX, collaboration, and cloud storage.
+- Discovery tab with trending templates/effects; learn tab with short lessons; spotlight for community remixes.
+
+## Success Metrics
+- Time-to-first-export; export success rate; retention by cohort; template adoption; co-edit session frequency; NPS and CSAT after review cycles.
+
+## Launch Readiness Checklist
+- Onboarding tutorial + sample project.
+- Stabilize key flows: import, trim, captions, export.
+- Offline support and sync conflict handling.
+- Analytics and privacy controls.
+- Support surface: crash reports, feedback widget, help center links.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CapCut-Style Editor Demo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="top-bar">
+      <div class="brand">Codex Cut</div>
+      <div class="actions">
+        <button class="ghost">Import</button>
+        <button class="primary">Export</button>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <aside class="panel media-panel">
+        <div class="panel-header">
+          <h2>Library</h2>
+          <p>Add demo clips to the timeline</p>
+        </div>
+        <div class="asset-list" id="assetList"></div>
+        <div class="panel-section">
+          <h3>Quick adds</h3>
+          <button class="primary block" id="addVideo">Add B-Roll Clip</button>
+          <button class="secondary block" id="addText">Add Text Overlay</button>
+        </div>
+      </aside>
+
+      <section class="preview-column">
+        <div class="preview-wrapper">
+          <div class="preview-stage">
+            <video id="preview" src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" controls></video>
+            <div id="textOverlay" class="text-overlay" aria-live="polite"></div>
+          </div>
+          <div class="transport">
+            <button id="playPause" class="primary">Play</button>
+            <label class="time-label">
+              <input type="range" id="scrubber" min="0" max="20" value="0" step="0.1" />
+              <span id="timeDisplay">0.0s</span>
+            </label>
+            <button id="addMarker" class="ghost">Add Marker</button>
+          </div>
+        </div>
+
+        <div class="timeline" id="timeline">
+          <div class="track-label">V1</div>
+          <div class="track" id="track"></div>
+        </div>
+      </section>
+
+      <aside class="panel inspector">
+        <div class="panel-header">
+          <h2>Inspector</h2>
+          <p>Edit the selected item</p>
+        </div>
+        <form id="inspectorForm" class="inspector-form">
+          <label>
+            Label
+            <input type="text" id="labelInput" name="label" placeholder="Clip name" />
+          </label>
+          <label>
+            Start (s)
+            <input type="number" id="startInput" name="start" step="0.1" min="0" />
+          </label>
+          <label>
+            Duration (s)
+            <input type="number" id="durationInput" name="duration" step="0.1" min="0.5" />
+          </label>
+          <label>
+            Text (for overlays)
+            <input type="text" id="textInput" name="text" placeholder="Your caption" />
+          </label>
+          <button type="submit" class="primary block">Update</button>
+        </form>
+        <div class="panel-section">
+          <h3>Markers</h3>
+          <ul id="markerList" class="marker-list"></ul>
+        </div>
+      </aside>
+    </main>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,194 @@
+const assets = [
+  {
+    id: 'clip-1',
+    label: 'Sunset Park',
+    duration: 5,
+    type: 'video',
+  },
+  {
+    id: 'clip-2',
+    label: 'City Drone',
+    duration: 6,
+    type: 'video',
+  },
+  {
+    id: 'clip-3',
+    label: 'Calm Waves',
+    duration: 4,
+    type: 'video',
+  },
+];
+
+const timeline = [];
+let selectedId = null;
+let markers = [];
+
+const assetList = document.getElementById('assetList');
+const track = document.getElementById('track');
+const inspectorForm = document.getElementById('inspectorForm');
+const labelInput = document.getElementById('labelInput');
+const startInput = document.getElementById('startInput');
+const durationInput = document.getElementById('durationInput');
+const textInput = document.getElementById('textInput');
+const preview = document.getElementById('preview');
+const textOverlay = document.getElementById('textOverlay');
+const scrubber = document.getElementById('scrubber');
+const timeDisplay = document.getElementById('timeDisplay');
+const playPause = document.getElementById('playPause');
+const addMarker = document.getElementById('addMarker');
+const markerList = document.getElementById('markerList');
+
+function renderAssets() {
+  assetList.innerHTML = '';
+  assets.forEach((asset) => {
+    const card = document.createElement('button');
+    card.className = 'asset-card';
+    card.innerHTML = `<div class="badge">${asset.type}</div><div>${asset.label}</div>`;
+    card.onclick = () => addClip(asset);
+    assetList.appendChild(card);
+  });
+}
+
+function addClip(asset) {
+  const start = timeline.reduce((acc, item) => acc + item.duration, 0);
+  const clip = {
+    id: `${asset.id}-${Date.now()}`,
+    label: asset.label,
+    duration: asset.duration,
+    start,
+    type: asset.type,
+    text: asset.type === 'text' ? 'Your overlay' : '',
+  };
+  timeline.push(clip);
+  selectClip(clip.id);
+  renderTimeline();
+}
+
+function addTextOverlay() {
+  const start = timeline.reduce((acc, item) => acc + item.duration, 0);
+  const clip = {
+    id: `text-${Date.now()}`,
+    label: 'Title',
+    duration: 3,
+    start,
+    type: 'text',
+    text: 'New caption',
+  };
+  timeline.push(clip);
+  selectClip(clip.id);
+  renderTimeline();
+}
+
+function renderTimeline() {
+  track.innerHTML = '';
+  if (!timeline.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Drop clips here to start building your edit.';
+    track.appendChild(empty);
+  }
+
+  timeline.forEach((clip) => {
+    const el = document.createElement('div');
+    el.className = `clip ${clip.type === 'text' ? 'text' : ''} ${
+      clip.id === selectedId ? 'selected' : ''
+    }`;
+    el.style.flexBasis = `${clip.duration * 30}px`;
+    el.innerHTML = `
+      <div class="meta">
+        <strong>${clip.label}</strong>
+        <span>${clip.duration.toFixed(1)}s</span>
+      </div>
+      <div class="meta">${clip.type === 'text' ? clip.text : 'Video'}</div>
+    `;
+    el.onclick = () => selectClip(clip.id);
+    track.appendChild(el);
+  });
+
+  const totalDuration = timeline.reduce((acc, clip) => acc + clip.duration, 0) || 20;
+  scrubber.max = totalDuration;
+}
+
+function selectClip(id) {
+  selectedId = id;
+  const clip = timeline.find((item) => item.id === id);
+  if (!clip) return;
+  labelInput.value = clip.label;
+  startInput.value = clip.start;
+  durationInput.value = clip.duration;
+  textInput.value = clip.text || '';
+  renderTimeline();
+}
+
+function updateClip(event) {
+  event.preventDefault();
+  const clip = timeline.find((item) => item.id === selectedId);
+  if (!clip) return;
+  clip.label = labelInput.value || clip.label;
+  clip.start = Math.max(0, parseFloat(startInput.value) || 0);
+  clip.duration = Math.max(0.5, parseFloat(durationInput.value) || clip.duration);
+  clip.text = textInput.value;
+  renderTimeline();
+}
+
+function syncPreview() {
+  const current = parseFloat(scrubber.value);
+  timeDisplay.textContent = `${current.toFixed(1)}s`;
+  const activeText = timeline.find(
+    (clip) => clip.type === 'text' && current >= clip.start && current <= clip.start + clip.duration
+  );
+  textOverlay.textContent = activeText ? activeText.text : '';
+}
+
+function togglePlay() {
+  if (preview.paused) {
+    preview.play();
+    playPause.textContent = 'Pause';
+  } else {
+    preview.pause();
+    playPause.textContent = 'Play';
+  }
+}
+
+function addTimelineMarker() {
+  const time = parseFloat(scrubber.value).toFixed(1);
+  markers.push(time);
+  renderMarkers();
+}
+
+function renderMarkers() {
+  markerList.innerHTML = '';
+  markers.forEach((time) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<span>${time}s</span><span class="badge">Marker</span>`;
+    markerList.appendChild(li);
+  });
+}
+
+preview.addEventListener('timeupdate', () => {
+  scrubber.value = preview.currentTime;
+  syncPreview();
+});
+
+preview.addEventListener('loadedmetadata', () => {
+  scrubber.max = preview.duration || 20;
+});
+
+scrubber.addEventListener('input', () => {
+  preview.currentTime = scrubber.value;
+  syncPreview();
+});
+
+playPause.addEventListener('click', togglePlay);
+addMarker.addEventListener('click', addTimelineMarker);
+inspectorForm.addEventListener('submit', updateClip);
+
+// Quick add buttons
+const addVideoBtn = document.getElementById('addVideo');
+const addTextBtn = document.getElementById('addText');
+addVideoBtn.addEventListener('click', () => addClip(assets[0]));
+addTextBtn.addEventListener('click', addTextOverlay);
+
+renderAssets();
+renderTimeline();
+renderMarkers();

--- a/script.js
+++ b/script.js
@@ -1,194 +1,322 @@
-const assets = [
-  {
-    id: 'clip-1',
-    label: 'Sunset Park',
-    duration: 5,
-    type: 'video',
-  },
-  {
-    id: 'clip-2',
-    label: 'City Drone',
-    duration: 6,
-    type: 'video',
-  },
-  {
-    id: 'clip-3',
-    label: 'Calm Waves',
-    duration: 4,
-    type: 'video',
-  },
-];
+// Minimal clip data powered editor demo
+// --------------------------------------------------
+// This file wires together the library, timeline, inspector, and playback
+// into a single-page experience that can add clips, edit them, scrub, and
+// jump via markers without any build tooling.
 
-const timeline = [];
-let selectedId = null;
-let markers = [];
+const PIXELS_PER_SECOND = 60;
 
-const assetList = document.getElementById('assetList');
-const track = document.getElementById('track');
-const inspectorForm = document.getElementById('inspectorForm');
-const labelInput = document.getElementById('labelInput');
-const startInput = document.getElementById('startInput');
-const durationInput = document.getElementById('durationInput');
-const textInput = document.getElementById('textInput');
-const preview = document.getElementById('preview');
-const textOverlay = document.getElementById('textOverlay');
-const scrubber = document.getElementById('scrubber');
-const timeDisplay = document.getElementById('timeDisplay');
-const playPause = document.getElementById('playPause');
-const addMarker = document.getElementById('addMarker');
-const markerList = document.getElementById('markerList');
+const state = {
+  assets: [
+    { id: 'asset-sunset', label: 'Sunset Park', duration: 3, type: 'video' },
+    { id: 'asset-city', label: 'City Drone', duration: 3, type: 'video' },
+    { id: 'asset-waves', label: 'Calm Waves', duration: 3, type: 'video' },
+  ],
+  clips: [],
+  markers: [],
+  selectedClipId: null,
+  activeClipId: null,
+};
 
+const elements = {
+  assetList: document.getElementById('assetList'),
+  track: document.getElementById('track'),
+  inspectorForm: document.getElementById('inspectorForm'),
+  labelInput: document.getElementById('labelInput'),
+  startInput: document.getElementById('startInput'),
+  durationInput: document.getElementById('durationInput'),
+  textInput: document.getElementById('textInput'),
+  preview: document.getElementById('preview'),
+  textOverlay: document.getElementById('textOverlay'),
+  scrubber: document.getElementById('scrubber'),
+  timeDisplay: document.getElementById('timeDisplay'),
+  playPause: document.getElementById('playPause'),
+  addMarker: document.getElementById('addMarker'),
+  markerList: document.getElementById('markerList'),
+  addVideoBtn: document.getElementById('addVideo'),
+  addTextBtn: document.getElementById('addText'),
+};
+
+// ---------- Helpers ----------
+function generateId(prefix) {
+  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+}
+
+function formatSeconds(value) {
+  return `${Number(value).toFixed(1)}s`;
+}
+
+function timelineEnd() {
+  return state.clips.reduce((max, clip) => Math.max(max, clip.start + clip.duration), 0);
+}
+
+function findClipById(id) {
+  return state.clips.find((clip) => clip.id === id);
+}
+
+function clipAtTime(time) {
+  return state.clips.find((clip) => time >= clip.start && time < clip.start + clip.duration);
+}
+
+// ---------- Rendering ----------
 function renderAssets() {
-  assetList.innerHTML = '';
-  assets.forEach((asset) => {
+  elements.assetList.innerHTML = '';
+  state.assets.forEach((asset) => {
     const card = document.createElement('button');
     card.className = 'asset-card';
     card.innerHTML = `<div class="badge">${asset.type}</div><div>${asset.label}</div>`;
-    card.onclick = () => addClip(asset);
-    assetList.appendChild(card);
+    card.onclick = () => addClipFromAsset(asset);
+    elements.assetList.appendChild(card);
   });
 }
 
-function addClip(asset) {
-  const start = timeline.reduce((acc, item) => acc + item.duration, 0);
+function renderTimeline() {
+  elements.track.innerHTML = '';
+  const sortedClips = [...state.clips].sort((a, b) => a.start - b.start);
+
+  if (!sortedClips.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Add clips from the library to start your sequence.';
+    elements.track.appendChild(empty);
+    setScrubberMax(20);
+    return;
+  }
+
+  let cursor = 0;
+  sortedClips.forEach((clip) => {
+    const spacerWidth = Math.max(0, clip.start - cursor);
+    if (spacerWidth > 0) {
+      const spacer = document.createElement('div');
+      spacer.className = 'spacer';
+      spacer.style.width = `${spacerWidth * PIXELS_PER_SECOND}px`;
+      elements.track.appendChild(spacer);
+    }
+
+    const clipEl = document.createElement('div');
+    clipEl.className = `clip ${clip.type === 'textOverlay' ? 'text' : ''}`;
+    if (state.selectedClipId === clip.id) clipEl.classList.add('selected');
+    if (state.activeClipId === clip.id) clipEl.classList.add('active');
+
+    clipEl.style.width = `${clip.duration * PIXELS_PER_SECOND}px`;
+    clipEl.innerHTML = `
+      <div class="meta">
+        <strong>${clip.label}</strong>
+        <span>${formatSeconds(clip.duration)}</span>
+      </div>
+      <div class="meta">${clip.type === 'textOverlay' ? clip.text || 'Text overlay' : 'Video clip'}</div>
+    `;
+    clipEl.onclick = () => selectClip(clip.id, { jumpToStart: true });
+    elements.track.appendChild(clipEl);
+
+    cursor = Math.max(cursor, clip.start + clip.duration);
+  });
+
+  setScrubberMax(cursor);
+}
+
+function renderMarkers() {
+  elements.markerList.innerHTML = '';
+
+  if (!state.markers.length) {
+    const empty = document.createElement('li');
+    empty.className = 'muted';
+    empty.textContent = 'No markers yet.';
+    elements.markerList.appendChild(empty);
+    return;
+  }
+
+  state.markers.forEach((marker) => {
+    const li = document.createElement('li');
+    li.className = 'marker-row';
+
+    const jumpBtn = document.createElement('button');
+    jumpBtn.type = 'button';
+    jumpBtn.className = 'ghost';
+    jumpBtn.textContent = formatSeconds(marker.time);
+    jumpBtn.onclick = () => seekTo(marker.time);
+
+    const label = document.createElement('input');
+    label.type = 'text';
+    label.value = marker.label;
+    label.onchange = (event) => updateMarkerLabel(marker.id, event.target.value);
+
+    li.appendChild(jumpBtn);
+    li.appendChild(label);
+    elements.markerList.appendChild(li);
+  });
+}
+
+function updateInspectorFromClip(clip) {
+  if (!clip) return;
+  elements.labelInput.value = clip.label;
+  elements.startInput.value = clip.start;
+  elements.durationInput.value = clip.duration;
+  elements.textInput.value = clip.text || '';
+  elements.textInput.disabled = clip.type !== 'textOverlay';
+  elements.textInput.placeholder = clip.type === 'textOverlay' ? 'Overlay text' : 'Text not applicable';
+}
+
+// ---------- Timeline + Inspector logic ----------
+function addClipFromAsset(asset) {
+  const start = timelineEnd();
   const clip = {
-    id: `${asset.id}-${Date.now()}`,
+    id: generateId('clip'),
     label: asset.label,
-    duration: asset.duration,
     start,
+    duration: asset.duration ?? 3,
     type: asset.type,
-    text: asset.type === 'text' ? 'Your overlay' : '',
+    text: asset.type === 'textOverlay' ? asset.text || 'New caption' : '',
   };
-  timeline.push(clip);
-  selectClip(clip.id);
+
+  state.clips.push(clip);
+  selectClip(clip.id, { jumpToStart: false });
   renderTimeline();
 }
 
 function addTextOverlay() {
-  const start = timeline.reduce((acc, item) => acc + item.duration, 0);
-  const clip = {
-    id: `text-${Date.now()}`,
-    label: 'Title',
+  const overlayAsset = {
+    id: 'asset-text',
+    label: 'Text Overlay',
     duration: 3,
-    start,
-    type: 'text',
-    text: 'New caption',
+    type: 'textOverlay',
+    text: 'Overlay title',
   };
-  timeline.push(clip);
-  selectClip(clip.id);
+  addClipFromAsset(overlayAsset);
+}
+
+function selectClip(id, { jumpToStart } = { jumpToStart: true }) {
+  const clip = findClipById(id);
+  if (!clip) return;
+  state.selectedClipId = clip.id;
+  state.activeClipId = clip.id;
+  updateInspectorFromClip(clip);
+  if (jumpToStart) seekTo(clip.start);
   renderTimeline();
 }
 
-function renderTimeline() {
-  track.innerHTML = '';
-  if (!timeline.length) {
-    const empty = document.createElement('div');
-    empty.className = 'empty-state';
-    empty.textContent = 'Drop clips here to start building your edit.';
-    track.appendChild(empty);
+function updateClipFromInspector(event) {
+  event.preventDefault();
+  const clip = findClipById(state.selectedClipId);
+  if (!clip) return;
+
+  clip.label = elements.labelInput.value.trim() || clip.label;
+  clip.start = Math.max(0, Number(elements.startInput.value) || 0);
+  clip.duration = Math.max(0.1, Number(elements.durationInput.value) || clip.duration);
+  if (clip.type === 'textOverlay') {
+    clip.text = elements.textInput.value;
   }
 
-  timeline.forEach((clip) => {
-    const el = document.createElement('div');
-    el.className = `clip ${clip.type === 'text' ? 'text' : ''} ${
-      clip.id === selectedId ? 'selected' : ''
-    }`;
-    el.style.flexBasis = `${clip.duration * 30}px`;
-    el.innerHTML = `
-      <div class="meta">
-        <strong>${clip.label}</strong>
-        <span>${clip.duration.toFixed(1)}s</span>
-      </div>
-      <div class="meta">${clip.type === 'text' ? clip.text : 'Video'}</div>
-    `;
-    el.onclick = () => selectClip(clip.id);
-    track.appendChild(el);
-  });
-
-  const totalDuration = timeline.reduce((acc, clip) => acc + clip.duration, 0) || 20;
-  scrubber.max = totalDuration;
-}
-
-function selectClip(id) {
-  selectedId = id;
-  const clip = timeline.find((item) => item.id === id);
-  if (!clip) return;
-  labelInput.value = clip.label;
-  startInput.value = clip.start;
-  durationInput.value = clip.duration;
-  textInput.value = clip.text || '';
+  state.clips.sort((a, b) => a.start - b.start);
   renderTimeline();
+  // Re-sync overlay in case text changed on an active clip
+  syncTime(previewCurrentTime());
 }
 
-function updateClip(event) {
-  event.preventDefault();
-  const clip = timeline.find((item) => item.id === selectedId);
-  if (!clip) return;
-  clip.label = labelInput.value || clip.label;
-  clip.start = Math.max(0, parseFloat(startInput.value) || 0);
-  clip.duration = Math.max(0.5, parseFloat(durationInput.value) || clip.duration);
-  clip.text = textInput.value;
-  renderTimeline();
+// ---------- Playback + time syncing ----------
+function setScrubberMax(totalTimeline) {
+  const videoDuration = elements.preview.duration || 0;
+  const maxValue = Math.max(totalTimeline, videoDuration, 15);
+  elements.scrubber.max = maxValue;
 }
 
-function syncPreview() {
-  const current = parseFloat(scrubber.value);
-  timeDisplay.textContent = `${current.toFixed(1)}s`;
-  const activeText = timeline.find(
-    (clip) => clip.type === 'text' && current >= clip.start && current <= clip.start + clip.duration
+function previewCurrentTime() {
+  return Number(elements.scrubber.value);
+}
+
+function syncTime(currentTime) {
+  elements.scrubber.value = currentTime;
+  elements.timeDisplay.textContent = formatSeconds(currentTime);
+  setActiveClipForTime(currentTime);
+  updateTextOverlay(currentTime);
+}
+
+function setActiveClipForTime(currentTime) {
+  const active = clipAtTime(currentTime);
+  const activeId = active ? active.id : null;
+  if (activeId !== state.activeClipId) {
+    state.activeClipId = activeId;
+    renderTimeline();
+  }
+}
+
+function updateTextOverlay(currentTime) {
+  const activeTextClip = state.clips.find(
+    (clip) => clip.type === 'textOverlay' && currentTime >= clip.start && currentTime < clip.start + clip.duration
   );
-  textOverlay.textContent = activeText ? activeText.text : '';
+  elements.textOverlay.textContent = activeTextClip ? activeTextClip.text : '';
 }
 
 function togglePlay() {
-  if (preview.paused) {
-    preview.play();
-    playPause.textContent = 'Pause';
+  if (elements.preview.paused) {
+    elements.preview.play();
+    elements.playPause.textContent = 'Pause';
   } else {
-    preview.pause();
-    playPause.textContent = 'Play';
+    elements.preview.pause();
+    elements.playPause.textContent = 'Play';
   }
 }
 
-function addTimelineMarker() {
-  const time = parseFloat(scrubber.value).toFixed(1);
-  markers.push(time);
+function seekTo(time) {
+  elements.preview.currentTime = time;
+  syncTime(time);
+}
+
+// ---------- Markers ----------
+function addMarkerAtCurrentTime() {
+  const time = Number(elements.preview.currentTime.toFixed(1));
+  const marker = {
+    id: generateId('marker'),
+    time,
+    label: `Marker ${state.markers.length + 1}`,
+  };
+  state.markers.push(marker);
   renderMarkers();
 }
 
-function renderMarkers() {
-  markerList.innerHTML = '';
-  markers.forEach((time) => {
-    const li = document.createElement('li');
-    li.innerHTML = `<span>${time}s</span><span class="badge">Marker</span>`;
-    markerList.appendChild(li);
-  });
+function updateMarkerLabel(id, label) {
+  const marker = state.markers.find((item) => item.id === id);
+  if (!marker) return;
+  marker.label = label.trim() || marker.label;
 }
 
-preview.addEventListener('timeupdate', () => {
-  scrubber.value = preview.currentTime;
-  syncPreview();
-});
+// ---------- Event wiring ----------
+function bindEvents() {
+  elements.playPause.addEventListener('click', togglePlay);
+  elements.scrubber.addEventListener('input', (event) => {
+    const time = Number(event.target.value);
+    elements.preview.currentTime = time;
+    syncTime(time);
+  });
 
-preview.addEventListener('loadedmetadata', () => {
-  scrubber.max = preview.duration || 20;
-});
+  elements.preview.addEventListener('timeupdate', () => {
+    const time = elements.preview.currentTime;
+    elements.scrubber.value = time;
+    syncTime(time);
+  });
 
-scrubber.addEventListener('input', () => {
-  preview.currentTime = scrubber.value;
-  syncPreview();
-});
+  elements.preview.addEventListener('loadedmetadata', () => {
+    setScrubberMax(timelineEnd());
+  });
 
-playPause.addEventListener('click', togglePlay);
-addMarker.addEventListener('click', addTimelineMarker);
-inspectorForm.addEventListener('submit', updateClip);
+  elements.addMarker.addEventListener('click', addMarkerAtCurrentTime);
+  elements.inspectorForm.addEventListener('submit', updateClipFromInspector);
+  elements.addVideoBtn.addEventListener('click', () => addClipFromAsset({
+    id: 'asset-broll',
+    label: 'B-Roll',
+    duration: 3,
+    type: 'video',
+  }));
+  elements.addTextBtn.addEventListener('click', addTextOverlay);
+}
 
-// Quick add buttons
-const addVideoBtn = document.getElementById('addVideo');
-const addTextBtn = document.getElementById('addText');
-addVideoBtn.addEventListener('click', () => addClip(assets[0]));
-addTextBtn.addEventListener('click', addTextOverlay);
+// ---------- Init ----------
+function init() {
+  renderAssets();
+  renderTimeline();
+  renderMarkers();
+  bindEvents();
+  syncTime(0);
+}
 
-renderAssets();
-renderTimeline();
-renderMarkers();
+init();

--- a/style.css
+++ b/style.css
@@ -123,6 +123,7 @@ body {
   text-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   font-weight: 600;
   font-size: 20px;
+  color: #fff;
 }
 
 .transport {
@@ -171,6 +172,12 @@ body {
   gap: 6px;
   align-items: center;
   overflow-x: auto;
+  position: relative;
+}
+
+.spacer {
+  flex: 0 0 auto;
+  height: 64px;
 }
 
 .clip {
@@ -183,6 +190,11 @@ body {
   position: relative;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.clip.active {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(109, 123, 255, 0.35);
 }
 
 .clip.text {
@@ -310,6 +322,19 @@ button.block {
   font-size: 14px;
 }
 
+.marker-row {
+  gap: 8px;
+}
+
+.marker-row input {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  color: var(--text);
+  flex: 1;
+}
+
 .badge {
   background: rgba(109, 123, 255, 0.15);
   border: 1px solid rgba(109, 123, 255, 0.5);
@@ -322,6 +347,10 @@ button.block {
 .empty-state {
   color: var(--muted);
   font-size: 14px;
+}
+
+.muted {
+  color: var(--muted);
 }
 
 @media (max-width: 1100px) {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,337 @@
+:root {
+  --bg: #0c0d11;
+  --panel: #13151c;
+  --accent: #6d7bff;
+  --muted: #888ca6;
+  --text: #f2f4ff;
+  --border: #1f2230;
+  --success: #67f0b6;
+}
+
+* {
+  box-sizing: border-box;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 10% 20%, rgba(109, 123, 255, 0.07), transparent 25%),
+    radial-gradient(circle at 90% 10%, rgba(103, 240, 182, 0.07), transparent 20%),
+    var(--bg);
+  color: var(--text);
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(12, 13, 17, 0.8);
+  backdrop-filter: blur(10px);
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.actions button + button {
+  margin-left: 10px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 260px 1fr 280px;
+  grid-template-rows: 1fr;
+  gap: 12px;
+  padding: 12px;
+  flex: 1;
+  min-height: 0;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+.panel-header h2 {
+  margin: 0 0 4px;
+}
+
+.panel-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.panel-section {
+  margin-top: 16px;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.preview-column {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.preview-wrapper {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+.preview-stage {
+  position: relative;
+  background: #0a0b10;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.preview-stage video {
+  width: 100%;
+  border-radius: 12px;
+  display: block;
+}
+
+.text-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  pointer-events: none;
+  padding: 16px;
+  text-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  font-weight: 600;
+  font-size: 20px;
+}
+
+.transport {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 4px 0;
+}
+
+.transport input[type='range'] {
+  width: 220px;
+}
+
+.time-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.timeline {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 10px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  min-height: 160px;
+}
+
+.track-label {
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.track {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 8px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  overflow-x: auto;
+}
+
+.clip {
+  background: linear-gradient(135deg, rgba(109, 123, 255, 0.4), rgba(109, 123, 255, 0.2));
+  border: 1px solid rgba(109, 123, 255, 0.5);
+  color: #fff;
+  padding: 10px 12px;
+  border-radius: 10px;
+  min-width: 100px;
+  position: relative;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.clip.text {
+  background: linear-gradient(135deg, rgba(103, 240, 182, 0.35), rgba(103, 240, 182, 0.15));
+  border: 1px solid rgba(103, 240, 182, 0.6);
+  color: #dffced;
+}
+
+.clip:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+}
+
+.clip.selected {
+  border-color: var(--success);
+  box-shadow: 0 0 0 2px rgba(103, 240, 182, 0.3);
+}
+
+.clip .meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #e9edff;
+  opacity: 0.9;
+}
+
+.buttons {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+}
+
+button.primary {
+  background: linear-gradient(135deg, #7b87ff, #5f6fff);
+  border: 1px solid rgba(123, 135, 255, 0.7);
+  box-shadow: 0 8px 24px rgba(95, 111, 255, 0.35);
+}
+
+button.secondary {
+  background: rgba(103, 240, 182, 0.08);
+  border-color: rgba(103, 240, 182, 0.5);
+  color: #dffced;
+}
+
+button.ghost {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+button.block {
+  width: 100%;
+}
+
+.asset-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.asset-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px;
+  text-align: center;
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.asset-card:hover {
+  border-color: rgba(123, 135, 255, 0.6);
+  transform: translateY(-2px);
+}
+
+.inspector-form {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.inspector label {
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.inspector input {
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+}
+
+.marker-list {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 0;
+  display: grid;
+  gap: 8px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.marker-list li {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+}
+
+.badge {
+  background: rgba(109, 123, 255, 0.15);
+  border: 1px solid rgba(109, 123, 255, 0.5);
+  border-radius: 8px;
+  padding: 2px 8px;
+  font-size: 12px;
+  color: #dfe4ff;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+@media (max-width: 1100px) {
+  .workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+  }
+
+  .panel.media-panel,
+  .inspector {
+    order: 2;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static CapCut-style editor demo with preview, transport, and timeline interactions
- style the interface with a dark theme and clear CTAs for adding clips and text overlays
- document how to run the demo via a simple local web server

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e758d07b4832f94a5db241c8e9405)